### PR TITLE
fix -> React Native community link has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Curated list of Uzbek Telegram dev groups
 
 - [@Androidchilar](https://t.me/Androidchilar)
 - [@java_kotlin_android_dasturlash](https://t.me/java_kotlin_android_dasturlash)
-- [@reactnative_uz](https://t.me/reactnative_uz)
+- [@reactnative_uzb](https://t.me/reactnative_uzb)
 - [@dartuzb](https://t.me/dartuzb)
 
 ## Community


### PR DESCRIPTION
Old community is link and private, new one has got bigger community now.

Please, update the current link and merge the PR.